### PR TITLE
Added b:cursorword_blacklist option

### DIFF
--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -2,7 +2,7 @@
 " Filename: autoload/cursorword.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2015/02/07 08:24:44.
+" Last Change: 2015/02/11 13:12:44.
 " =============================================================================
 
 let s:save_cpo = &cpo
@@ -24,6 +24,8 @@ function! cursorword#matchadd() abort
   let line = getline('.')
   let linenr = line('.')
   let word = matchstr(line[:(col('.')-1)], '\k*$')[:-2] . matchstr(line[(col('.')-1):], '^\k*')
+  " skip blacklisted words
+  if index(get(b:, 'cursorword_blacklist', []), word) >=0 | return | endif
   if get(w:, 'cursorword_state', []) ==# [ linenr, word, enable ] | return | endif
   let w:cursorword_state = [ linenr, word, enable ]
   silent! call matchdelete(w:cursorword_id0)

--- a/doc/cursorword.txt
+++ b/doc/cursorword.txt
@@ -9,6 +9,7 @@ Last Change: 2015/02/11 12:12:47.
 CONTENTS					*cursorword-contents*
 
 Introduction				|cursorword-introduction|
+Options					|cursorword-options|
 Changelog				|cursorword-changelog|
 
 ==============================================================================
@@ -34,8 +35,8 @@ plugin which stays running in all buffers, we should be aware that it will use
 much resource of all the users.
 
 The code of |cursorword| is very tiny. It's very tiny that |cursorword| runs ten
-times faster than brightest. Instead of its efficiency, |cursorword| is totally
-unconfigurable. But you will find this plugin just comfortable; the modest
+times faster than brightest. Instead of its efficiency, |cursorword| supports
+only one option. But you will find this plugin just comfortable; the modest
 underlines are enough for us. A good configurable plugin would have many
 options that users can configure almost all the features. But be relaxed and
 imagine, do we need such a lot of options for a plugin to highlight the word
@@ -47,7 +48,20 @@ unwanted slowness on many users. We have to rethink what good configurability
 is and for what kind of software such configurability is required.
 
 ==============================================================================
+OPTIONS						*cursorword-options*
+------------------------------------------------------------------------------
+						*b:cursorword_blacklist*
+Use this options to control which words will not be underlined.
+Default: []. Values: list of strings.
+>
+    let b:cursorword_blacklist = ['self', 'def', 'import']
+<
+
+==============================================================================
 CHANGELOG					*cursorword-changelog*
+
+0.3	2014-02-11
+	- Added cursorword_blacklist option
 
 0.2	2014-02-10
 	- Call cursorword#highlight on loading the autoload script.


### PR DESCRIPTION
First of all, thanks for this nice plugin.
In general I agree with your opinion about heavy configurability.
But I think the black list options will be very useful because I don't want to underline, for example, program language's keywords. That's why I've written this request. 
