### PR TITLE
Highlight style option

### DIFF
--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -10,7 +10,8 @@ set cpo&vim
 
 function! cursorword#highlight() abort
   if !get(g:, 'cursorword_highlight', 1) | return | endif
-  highlight CursorWord0 term=underline cterm=underline gui=underline
+  let l:style = get(g:, 'cursorword_highlight_style', "term=underline cterm=underline gui=underline")
+  execute("highlight CursorWord0 " . l:style)
   redir => out
     silent! highlight CursorLine
   redir END

--- a/doc/cursorword.txt
+++ b/doc/cursorword.txt
@@ -57,6 +57,14 @@ OPTIONS						*cursorword-options*
 		If you set this variable to 0, the plugin stops highlighting
 		the word under the cursor in the buffer. This variable has
 		priority over |g:cursorword|.
+		
+	g:cursorword_highlight_style		*g:cursorword_highlight_style*
+		Define the style for highlighting all matches.
+		E.g.:	let g:cursorword_highlight_style = "ctermfg:9
+				\ guifg=#ff0000 cterm=undercurl gui=undercurl"
+
+		See |highlight| for further information how to define such.
+		Default: "term=underline cterm=underline gui=underline"
 
 ==============================================================================
 CHANGELOG					*cursorword-changelog*


### PR DESCRIPTION
First: Thanks for this simple, but great plugin. Its fast and helps a lot.<br>
This simple new global variable allows the user to define how the highlight should look like. For example I've customized syntax highlights and a simple underline doesn't attrack much attention.<br>
By the default value for this variable, users should not be affected negativly by this, but get the option to customize this plugin in a simple manner.