### PR TITLE
Syntax groups inclusion/exclusion

### DIFF
--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -2,7 +2,7 @@
 " Filename: autoload/cursorword.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2017/09/29 20:00:00.
+" Last Change: 2018/04/19 13:58:10.
 " =============================================================================
 
 let s:save_cpo = &cpo
@@ -57,7 +57,7 @@ function! cursorword#matchadd(...) abort
   silent! call matchdelete(w:cursorword_id0)
   silent! call matchdelete(w:cursorword_id1)
   let w:cursorword_match = 0
-  if !enable || cursorword#inmatchgroup() == 0 || word ==# '' || len(word) !=# strchars(word) && word !~# s:alphabets || len(word) > 1000 | return | endif
+  if !enable || word ==# '' || len(word) !=# strchars(word) && word !~# s:alphabets || len(word) > 1000 || !cursorword#inmatchgroup() | return | endif
   let pattern = '\<' . escape(word, '~"\.^$[]*') . '\>'
   let w:cursorword_id0 = matchadd('CursorWord0', pattern, -1)
   let w:cursorword_id1 = matchadd('CursorWord' . &l:cursorline, '\%' . linenr . 'l' . pattern, -1)

--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -20,6 +20,15 @@ endfunction
 
 let s:alphabets = '^[\x00-\x7f\xb5\xc0-\xd6\xd8-\xf6\xf8-\u01bf\u01c4-\u02af\u0370-\u0373\u0376\u0377\u0386-\u0481\u048a-\u052f]\+$'
 
+function! cursorword#inmatchgroup() abort
+  let matching_groups = get(g:, 'cursorword_match_groups', [])
+  let current_syntax_groups = [ synIDattr(synID(line("."),col("."),1),"name"), synIDattr(synIDtrans(synID(line("."),col("."),1)),"name"), synIDattr(synID(line("."),col("."),0),"name") ]
+  if (len(matching_groups) > 0 && index(matching_groups, current_syntax_groups[0]) < 0 && index(matching_groups, current_syntax_groups[1]) < 0 && index(matching_groups, current_syntax_groups[2]) < 0)
+    return 0
+  endif
+  return 1
+endfunction
+
 function! cursorword#matchadd(...) abort
   let enable = get(b:, 'cursorword', get(g:, 'cursorword', 1)) && !has('vim_starting')
   if !enable && !get(w:, 'cursorword_match') | return | endif
@@ -32,12 +41,13 @@ function! cursorword#matchadd(...) abort
   silent! call matchdelete(w:cursorword_id0)
   silent! call matchdelete(w:cursorword_id1)
   let w:cursorword_match = 0
-  if !enable || word ==# '' || len(word) !=# strchars(word) && word !~# s:alphabets || len(word) > 1000 | return | endif
+  if !enable || cursorword#inmatchgroup() == 0 || word ==# '' || len(word) !=# strchars(word) && word !~# s:alphabets || len(word) > 1000 | return | endif
   let pattern = '\<' . escape(word, '~"\.^$[]*') . '\>'
   let w:cursorword_id0 = matchadd('CursorWord0', pattern, -1)
   let w:cursorword_id1 = matchadd('CursorWord' . &l:cursorline, '\%' . linenr . 'l' . pattern, -1)
   let w:cursorword_match = 1
 endfunction
+
 
 if !has('vim_starting')
   call cursorword#highlight()

--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -22,8 +22,24 @@ let s:alphabets = '^[\x00-\x7f\xb5\xc0-\xd6\xd8-\xf6\xf8-\u01bf\u01c4-\u02af\u03
 
 function! cursorword#inmatchgroup() abort
   let matching_groups = get(g:, 'cursorword_match_groups', [])
-  let current_syntax_groups = [ synIDattr(synID(line("."),col("."),1),"name"), synIDattr(synIDtrans(synID(line("."),col("."),1)),"name"), synIDattr(synID(line("."),col("."),0),"name") ]
-  if (len(matching_groups) > 0 && index(matching_groups, current_syntax_groups[0]) < 0 && index(matching_groups, current_syntax_groups[1]) < 0 && index(matching_groups, current_syntax_groups[2]) < 0)
+  let exclude_groups = get(g:, 'cursorword_exclude_groups', [])
+  let current_syntax_groups = [
+      \synIDattr(synID(line("."),col("."),1),"name"),
+      \synIDattr(synIDtrans(synID(line("."),col("."),1)),"name"),
+      \synIDattr(synID(line("."),col("."),0),"name")
+    \]
+  if (
+        \(len(matching_groups) > 0
+        \&& index(matching_groups, current_syntax_groups[0]) < 0
+        \&& index(matching_groups, current_syntax_groups[1]) < 0
+        \&& index(matching_groups, current_syntax_groups[2]) < 0)
+        \|| (len(exclude_groups) > 0 && (
+        \index(exclude_groups, current_syntax_groups[0]) >= 0
+        \|| index(exclude_groups, current_syntax_groups[1]) >= 0
+        \|| index(exclude_groups, current_syntax_groups[2]) >= 0
+        \)
+        \)
+        \)
     return 0
   endif
   return 1

--- a/doc/cursorword.txt
+++ b/doc/cursorword.txt
@@ -53,6 +53,16 @@ OPTIONS						*cursorword-options*
 	g:cursorword				*g:cursorword*
 		Set this variable to 0 to disable this plugin globally.
 
+	g:cursorword_match_groups	*g:cursorword_match_groups*
+		Set this variable to an array of syntax groups to underline
+		only those groups. An emtpy array is the default, which will
+		match all syntax groups.
+
+	g:cursorword_exclude_groups	*g:cursorword_exclude_groups*
+		Set this variable to an array of syntax groups to exclude
+		those groups from underlining. An emtpy array is the default,
+		which will exclude no syntax groups.
+
 	b:cursorword				*b:cursorword*
 		If you set this variable to 0, the plugin stops highlighting
 		the word under the cursor in the buffer. This variable has

--- a/doc/cursorword.txt
+++ b/doc/cursorword.txt
@@ -54,14 +54,20 @@ OPTIONS						*cursorword-options*
 		Set this variable to 0 to disable this plugin globally.
 
 	g:cursorword_match_groups	*g:cursorword_match_groups*
-		Set this variable to an array of syntax groups to underline
-		only those groups. An emtpy array is the default, which will
+		Set this variable to a list of syntax groups to underline
+		only those groups. An emtpy list is the default, which will
 		match all syntax groups.
+>
+	let g:cursorword_match_groups = ['Identifier', 'String']
+<
 
 	g:cursorword_exclude_groups	*g:cursorword_exclude_groups*
-		Set this variable to an array of syntax groups to exclude
-		those groups from underlining. An emtpy array is the default,
-		which will exclude no syntax groups.
+		Set this variable to a list of syntax groups to exclude those
+		groups from underlining. An emtpy list is the default, which
+		will exclude no syntax groups.
+>
+	let g:cursorword_exclude_groups = ['Statement', 'Keyword']
+<
 
 	b:cursorword				*b:cursorword*
 		If you set this variable to 0, the plugin stops highlighting


### PR DESCRIPTION
I've added two options to allow configuration of a whitelist and/or blacklist of syntax groups to highlight.
One might use a configuration such as this:
```vim
" Only match these syntax groups
let g:cursorword_match_groups = ['Identifier', 'String', 'Number', '']
" Including an empty string will generally match unstyled identifiers in highlighting schemes like Python or JavaScript

" Don't match these syntax groups
let g:cursorword_exclude_groups = ['Statement', 'Keyword']
```
I saw that a similar pull request was rejected in order to keep the plugin simple and performant. However, I find this a necessity for my own use of the plugin. Highlighting language keywords is distracting, and I haven't noticed a performance drop.
Please let me know what you think and if you'd like any changes or feel free to reject if you feel it doesn't meet the project goals.