### PR TITLE
Fix error message when vim-cursorword is installed

### DIFF
--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -21,6 +21,7 @@ endfunction
 let s:alphabets = '^[\x00-\x7f\xb5\xc0-\xd6\xd8-\xf6\xf8-\u01bf\u01c4-\u02af\u0370-\u0373\u0376\u0377\u0386-\u0481\u048a-\u052f]\+$'
 
 function! cursorword#matchadd(...) abort
+  if !hlexists('CursorWord0') | call cursorword#highlight() | endif
   let enable = get(b:, 'cursorword', get(g:, 'cursorword', 1)) && !has('vim_starting')
   if !enable && !get(w:, 'cursorword_match') | return | endif
   let i = (a:0 ? a:1 : mode() ==# 'i' || mode() ==# 'R') && col('.') > 1

--- a/plugin/cursorword.vim
+++ b/plugin/cursorword.vim
@@ -15,8 +15,6 @@ set cpo&vim
 
 augroup cursorword
   autocmd!
-  autocmd VimEnter * call cursorword#highlight() |
-        \ autocmd cursorword WinEnter,BufEnter * call cursorword#matchadd()
   autocmd ColorScheme * call cursorword#highlight()
   autocmd CursorMoved,CursorMovedI * call cursorword#cursormoved()
   autocmd InsertEnter * call cursorword#matchadd(1)


### PR DESCRIPTION
Hi -- thanks for the great plugin!

I've been getting this error every time I install `vim-cursorword`:
![image](https://user-images.githubusercontent.com/6992947/80277393-78a39880-86a3-11ea-8bf3-bb355f6fef92.png)

This is because highlight groups are currently only added on the `VimEnter` & `Colorscheme` events, neither of which will be triggered unless Vim is closed & then re-opened.

Proposing to move the `cursorword#highlight` call to `cursorword#matchadd`. Adds a few more clock cycles to the timer callback, but should be insignificant.