### PR TITLE
(Attempt #2) Fix error message when vim-cursorword is installed

### DIFF
--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -2,21 +2,11 @@
 " Filename: autoload/cursorword.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2020/03/19 14:34:17.
+" Last Change: 2020/04/26 00:33:24.
 " =============================================================================
 
 let s:save_cpo = &cpo
 set cpo&vim
-
-function! cursorword#highlight() abort
-  if !get(g:, 'cursorword_highlight', 1) | return | endif
-  highlight CursorWord0 term=underline cterm=underline gui=underline
-  redir => out
-    silent! highlight CursorLine
-  redir END
-  let highlight = 'highlight CursorWord1 term=underline cterm=underline gui=underline'
-  execute highlight matchstr(out, 'ctermbg=#\?\w\+') matchstr(out, 'guibg=#\?\w\+')
-endfunction
 
 let s:alphabets = '^[\x00-\x7f\xb5\xc0-\xd6\xd8-\xf6\xf8-\u01bf\u01c4-\u02af\u0370-\u0373\u0376\u0377\u0386-\u0481\u048a-\u052f]\+$'
 

--- a/plugin/cursorword.vim
+++ b/plugin/cursorword.vim
@@ -2,7 +2,7 @@
 " Filename: plugin/cursorword.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2020/03/10 11:57:22.
+" Last Change: 2020/04/26 00:33:47.
 " =============================================================================
 
 if exists('g:loaded_cursorword') || v:version < 703
@@ -13,11 +13,21 @@ let g:loaded_cursorword = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:cursorword_highlights() abort
+  if !get(g:, 'cursorword_highlight', 1) | return | endif
+  highlight CursorWord0 term=underline cterm=underline gui=underline
+  redir => out
+    silent! highlight CursorLine
+  redir END
+  let highlight = 'highlight CursorWord1 term=underline cterm=underline gui=underline'
+  execute highlight matchstr(out, 'ctermbg=#\?\w\+') matchstr(out, 'guibg=#\?\w\+')
+endfunction
+
+call s:cursorword_highlights()
+
 augroup cursorword
   autocmd!
-  autocmd VimEnter * call cursorword#highlight() |
-        \ autocmd cursorword WinEnter,BufEnter * call cursorword#matchadd()
-  autocmd ColorScheme * call cursorword#highlight()
+  autocmd ColorScheme * call s:cursorword_highlights()
   autocmd CursorMoved,CursorMovedI * call cursorword#cursormoved()
   autocmd InsertEnter * call cursorword#matchadd(1)
   autocmd InsertLeave * call cursorword#matchadd(0)


### PR DESCRIPTION
Hi!

New PR that solves the issue brought up in #21 without the repeated highlight check.

Understandable that this isn't an important edge case (feel free to close this also), but wanted to get your thoughts on this solution. cursorword is one of my favorites of the few dozen plugins I have, but also the only one that gives me an error every time I install it.

Notes:

- This increases startup time from ~0.1 milliseconds to ~0.15 milliseconds on my machine.
- Tested on Vim 7.4 & 8 without issues.