### PR TITLE
Don't remove highlighting on every CursorMoved

### DIFF
--- a/autoload/cursorword.vim
+++ b/autoload/cursorword.vim
@@ -2,7 +2,7 @@
 " Filename: autoload/cursorword.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2020/06/20 14:12:12.
+" Last Change: 2020/11/10 21:00:31.
 " =============================================================================
 
 let s:save_cpo = &cpo
@@ -45,12 +45,6 @@ let s:delay = get(g:, 'cursorword_delay', 50)
 if has('timers') && s:delay > 0
   let s:timer = 0
   function! cursorword#cursormoved() abort
-    if get(w:, 'cursorword_match')
-      silent! call matchdelete(w:cursorword_id0)
-      silent! call matchdelete(w:cursorword_id1)
-      let w:cursorword_match = 0
-      let w:cursorword_state = []
-    endif
     call timer_stop(s:timer)
     let s:timer = timer_start(s:delay, 'cursorword#timer_callback')
   endfunction


### PR DESCRIPTION
Basically, this calls `matchdelete` only in the timer callback. It removes annoying blinking (without setting the delay option to a small value, which decreases performance).

Old:

![old](https://user-images.githubusercontent.com/10106819/98733773-f48fd480-2398-11eb-8301-d668232dfb70.gif)

New:

![new](https://user-images.githubusercontent.com/10106819/98733820-040f1d80-2399-11eb-9a64-728f81f61eff.gif)

The diasadvantage is that the underline won't be deleted if one repeats hjkl:

![3](https://user-images.githubusercontent.com/10106819/98733833-096c6800-2399-11eb-8ee4-773c45e5dafa.gif)

I think the new behaviour is better, but if you disagree, I can add a little option.
